### PR TITLE
Now NaN (not a number) commands for wheels don't cause crash on FIRASim

### DIFF
--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -595,6 +595,12 @@ void SSLWorld::recvActions()
                     int id = robotIndex(robot_cmd.id(), robot_cmd.yellowteam());
                     if ((id < 0) || (id >= cfg->Robots_Count() * 2))
                         continue;
+                        
+                    if (isnanf(robot_cmd.wheel_left()) || isnanf(robot_cmd.wheel_right())){
+                    	std::cout << "[ERROR] Received an NaN (not a number) command for wheels by team " << (robot_cmd.yellowteam() ? "yellow" : "blue") << std::endl;
+                    	continue;
+                    }
+                        
                     robots[id]->setSpeed(0, -1 * robot_cmd.wheel_left());
                     robots[id]->setSpeed(1, robot_cmd.wheel_right());
                 }


### PR DESCRIPTION
Even with minimal chance, it is possible that during some treatment error in divisions by zero, teams send packages with an invalid speed value to the wheels (usually a not a number), which causes an error in the physical ODE of FIRASim and leading to a possible crash.
To avoid this, a conditional was created to check if any of the two speeds put on the wheels is an invalid number, ignoring the package in case this conditional is true and sending an error message to the output console.