### PR TITLE
Remove robot dummy chassis and fix robot bottom height calculations

### DIFF
--- a/config/Parsian.ini
+++ b/config/Parsian.ini
@@ -2,7 +2,7 @@
 CenterFromKicker= 0.05
 Radius = 0.0375
 Height = 0.075
-RobotBottomZValue = 0.02
+RobotBottomZValue = 0.00125
 KickerZValue = 0.005
 KickerThickness = 0.005
 KickerWidth = 0.08

--- a/config/Parsian.ini
+++ b/config/Parsian.ini
@@ -16,11 +16,11 @@ BallMass=0.001
 [Physics]
 Bodymass = 1
 Wheelmass = 0.2
-Kickermass =0.02
+Kickermass = 0.02
 KickerDampFactor = 0.2
 RollerTorqueFactor = 0.06
 RollerPerpendicularTorqueFactor = 0.005
 KickerFriction = 0.8
 WheelTangentFriction = 0.8
 WheelPerpendicularFriction = 1
-WheelMotorMaximumApplyingTorque= 0.2
+WheelMotorMaximumApplyingTorque = 0.11

--- a/include/robot.h
+++ b/include/robot.h
@@ -49,8 +49,6 @@ public:
     ConfigWidget *cfg;
     dSpaceID space;
     PObject *chassis;
-    PBox *dummy;
-    dJointID dummy_to_chassis;
     PBox *boxes[3]{};
     bool on;
     //these values are not controled by this class

--- a/include/robot.h
+++ b/include/robot.h
@@ -101,6 +101,6 @@ public:
     PWorld *getWorld();
 };
 
-#define ROBOT_START_Z(cfg) ((cfg)->robotSettings.RobotHeight * 0.5 + (cfg)->robotSettings.WheelRadius * 1 + (cfg)->robotSettings.BottomHeight)
+#define ROBOT_START_Z(cfg) ((cfg)->robotSettings.RobotHeight * 0.5 + (cfg)->robotSettings.BottomHeight)
 
 #endif // ROBOT_H

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -110,17 +110,9 @@ CRobot::CRobot(PWorld *world, PBall *ball, ConfigWidget *_cfg, dReal x, dReal y,
 
     space = w->space;
 
-    chassis = new PBox(x, y, z, cfg->robotSettings.RobotRadius * 2, cfg->robotSettings.RobotRadius * 2, cfg->robotSettings.RobotHeight, cfg->robotSettings.BodyMass * 0.99f, r, g, b, rob_id, true);
+    chassis = new PBox(x, y, z, cfg->robotSettings.RobotRadius * 2, cfg->robotSettings.RobotRadius * 2, cfg->robotSettings.RobotHeight, cfg->robotSettings.BodyMass, r, g, b, rob_id, true);
     chassis->space = space;
     w->addObject(chassis);
-
-    dummy = new PBox(x, y, z, cfg->robotSettings.RobotRadius * 2, cfg->robotSettings.RobotRadius * 2, cfg->robotSettings.RobotHeight, cfg->robotSettings.BodyMass * 0.99f, r, g, b, rob_id, true);
-    dummy->setVisibility(false);
-    dummy->space = space;
-    w->addObject(dummy);
-
-    dummy_to_chassis = dJointCreateFixed(world->world, nullptr);
-    dJointAttach(dummy_to_chassis, chassis->body, dummy->body);
 
     wheels[0] = new Wheel(this, 0, cfg->robotSettings.Wheel1Angle, cfg->robotSettings.Wheel1Angle, wheeltexid);
     wheels[1] = new Wheel(this, 1, cfg->robotSettings.Wheel2Angle, cfg->robotSettings.Wheel2Angle, wheeltexid);
@@ -237,8 +229,6 @@ void CRobot::resetRobot()
     resetSpeeds();
     dBodySetLinearVel(chassis->body, 0, 0, 0);
     dBodySetAngularVel(chassis->body, 0, 0, 0);
-    dBodySetLinearVel(dummy->body, 0, 0, 0);
-    dBodySetAngularVel(dummy->body, 0, 0, 0);
     for (auto &wheel : wheels)
     {
         dBodySetLinearVel(wheel->cyl->body, 0, 0, 0);
@@ -287,7 +277,6 @@ void CRobot::setXY(dReal x, dReal y)
     dReal height = ROBOT_START_Z(cfg);
     chassis->getBodyPosition(xx, yy, zz);
     chassis->setBodyPosition(x, y, height);
-    dummy->setBodyPosition(x, y, height);
     for (auto &wheel : wheels)
     {
         wheel->cyl->getBodyPosition(kx, ky, kz);
@@ -299,7 +288,6 @@ void CRobot::setDir(dReal ang)
 {
     ang *= M_PI / 180.0f;
     chassis->setBodyRotation(0, 0, 1, ang);
-    dummy->setBodyRotation(0, 0, 1, ang);
     dMatrix3 wLocalRot, wRot, cRot;
     dVector3 localPos, finalPos, cPos;
     chassis->getBodyPosition(cPos[0], cPos[1], cPos[2], false);

--- a/src/robot.cpp
+++ b/src/robot.cpp
@@ -32,7 +32,7 @@ CRobot::Wheel::Wheel(CRobot *robot, int _id, dReal ang, dReal ang2, int wheeltex
     dReal z = rob->m_z;
     dReal centerx = x + rad * cos(ang2);
     dReal centery = y + rad * sin(ang2);
-    dReal centerz = z - rob->cfg->robotSettings.RobotRadius * 0.5 + rob->cfg->robotSettings.WheelRadius - rob->cfg->robotSettings.BottomHeight;
+    dReal centerz = z - rob->cfg->robotSettings.RobotHeight * 0.5 - rob->cfg->robotSettings.BottomHeight + rob->cfg->robotSettings.WheelRadius;
     cyl = new PCylinder(centerx, centery, centerz, rob->cfg->robotSettings.WheelRadius, rob->cfg->robotSettings.WheelThickness, rob->cfg->robotSettings.WheelMass, 0.9, 0.9, 0.9, wheeltexid);
     cyl->setRotation(-sin(ang), cos(ang), 0, M_PI * 0.5);
     cyl->setBodyRotation(-sin(ang), cos(ang), 0, M_PI * 0.5, true);    //set local rotation matrix
@@ -74,7 +74,7 @@ CRobot::RBall::RBall(CRobot *robot, int _id, dReal ang, dReal ang2)
     dReal z = rob->m_z;
     dReal centerx = x + rad * cos(ang2);
     dReal centery = y + rad * sin(ang2);
-    dReal centerz = z - rob->cfg->robotSettings.RobotRadius * 0.5 + rob->cfg->robotSettings.BallRadius - rob->cfg->robotSettings.BottomHeight;
+    dReal centerz = z - rob->cfg->robotSettings.RobotHeight * 0.5 - rob->cfg->robotSettings.BottomHeight + rob->cfg->robotSettings.BallRadius;
     pBall = new PBall(centerx, centery, centerz, rob->cfg->robotSettings.BallRadius, rob->cfg->robotSettings.BallMass, 1, 0, 0);
     pBall->setRotation(-sin(ang), cos(ang), 0, M_PI * 0.5);
     pBall->setBodyRotation(-sin(ang), cos(ang), 0, M_PI * 0.5, true);    //set local rotation matrix

--- a/src/sslworld.cpp
+++ b/src/sslworld.cpp
@@ -99,7 +99,7 @@ bool rayCallback(dGeomID o1, dGeomID o2, PSurface *s, int robots_count)
         obj = o1;
     for (int i = 0; i < robots_count * 2; i++)
     {
-        if (_w->robots[i]->chassis->geom == obj || _w->robots[i]->dummy->geom == obj)
+        if (_w->robots[i]->chassis->geom == obj)
         {
             _w->robots[i]->selected = true;
             _w->robots[i]->select_x = s->contactPos[0];
@@ -302,7 +302,6 @@ SSLWorld::SSLWorld(QGLWidget *parent, ConfigWidget *_cfg, RobotsFormation *form)
     for (int k = 0; k < cfg->Robots_Count() * 2; k++)
     {
         p->createSurface(ray, robots[k]->chassis)->callback = rayCallback;
-        p->createSurface(ray, robots[k]->dummy)->callback = rayCallback;
     }
     PSurface ballwithwall;
     ballwithwall.surface.mode = dContactBounce | dContactApprox1; // | dContactSlip1;
@@ -324,8 +323,7 @@ SSLWorld::SSLWorld(QGLWidget *parent, ConfigWidget *_cfg, RobotsFormation *form)
         p->createSurface(robots[k]->chassis, ground);
         for (auto &wall : walls)
             p->createSurface(robots[k]->chassis, wall);
-        p->createSurface(robots[k]->dummy, ball);
-        //p->createSurface(robots[k]->chassis,ball);
+        p->createSurface(robots[k]->chassis,ball);
         for (auto &wheel : robots[k]->wheels)
         {
             p->createSurface(wheel->cyl, ball);
@@ -346,7 +344,7 @@ SSLWorld::SSLWorld(QGLWidget *parent, ConfigWidget *_cfg, RobotsFormation *form)
         {
             if (k != j)
             {
-                p->createSurface(robots[k]->dummy, robots[j]->dummy); //seams ode doesn't understand cylinder-cylinder contacts, so I used spheres
+                p->createSurface(robots[k]->chassis, robots[j]->chassis); //seams ode doesn't understand cylinder-cylinder contacts, so I used spheres
             }
         }
     }


### PR DESCRIPTION
### Identify the Bug
- #6 - Robot config bottom Z value was not working as intended, the value selected there did not correspond to the robot "body" distance from field floor

- #5 - Robot chassis "dummy" object is being created, without being necessary. This object was initially implemented to circumvent a collision detection issue occurring on SSL robots since they used a cylinder shape, this is not necessary for the VSS robot since it has a rectangular body

### Description of the Change
- Removed dummy object creation and removed surfaces which used it, for collision function it was changed to use the chassis instead

- Changed Robot_Start_Z calculations to place a robot at its correct height and changed robot Wheel and RBall z position calculation to the correct one
- Changed Robot motor parameter to maintain previous robot dynamic
- Robot configuration values should be now more representative of the actual robot value

### Alternate Designs
 - Keeping the dummy object should not interfere with the final simulation result, but may slow down the code
 
 - I tried changing robot weight instead of motor parameters to maintain previous dynamics, but it did not work as expected

### Possible Drawbacks
- Changing robot configuration may affect teams control, but since the config was changed to preserve robot dynamics, nothing should change

### Verification Process
- Tested if collisions are still working as intended
- Checked if robot acceleration is the same as previous changes

### Release Notes

- Removed dummy robot object as it is not necessary, and fixed robot height calculation to match the value selected on the robot config file
